### PR TITLE
Menu activity detection fix

### DIFF
--- a/prefabs/app/Livewire/User/DataTable.php
+++ b/prefabs/app/Livewire/User/DataTable.php
@@ -30,6 +30,7 @@ class DataTable extends DataTableComponent
             'id'    => __('ID'),
             'name'  => __('Name'),
             'email' => __('E-mail'),
+			'totp_force' => __('Enforce MFA')
         ];
     }
 
@@ -68,5 +69,27 @@ class DataTable extends DataTableComponent
     public function edit($id)
     {
         $this->dispatch('openModal', 'user.form', __('Edit user'), ['user_id' => $id]);
+    }
+
+	   public function renderColumnTotpForce($value, $row)
+    {
+        $button = '';
+        if (! empty($value)) {
+            $button = '<i class="fa fa-check-circle text-success"></i>';
+        } else {
+            $button = '<i class="fa fa-times-circle text-danger"></i>';
+        }
+
+        return '<button class="btn btn-link" wire:click="change('.$row['id'].',\'totp_force\')">'.$button.'</button>';
+    }
+
+    public function change($id, $name)
+    {
+        $user = User::where('id', $id)->first();
+        $data = [
+            $name => ! $user->{$name},
+        ];
+        $user->update($data);
+        $this->dispatch('closeModal');
     }
 }

--- a/prefabs/app/Models/User.php
+++ b/prefabs/app/Models/User.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Cache;
 use Laravel\Sanctum\HasApiTokens;
 use SteelAnts\LaravelBoilerplate\Traits\Auditable;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use SteelAnts\LaravelBoilerplate\Models\Session;
 
 #[ObservedBy([UserObserver::class])]
 class User extends Authenticatable

--- a/prefabs/app/Models/User.php
+++ b/prefabs/app/Models/User.php
@@ -29,6 +29,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+		'totp_force',
     ];
 
     /**
@@ -39,6 +40,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+		'totp_secret',
     ];
 
     /**

--- a/prefabs/resources/views/auth/totp.blade.php
+++ b/prefabs/resources/views/auth/totp.blade.php
@@ -1,0 +1,22 @@
+<x-layout-auth>
+<div>
+    <h1>{{ __('Two-factor authentication') }}</h1>
+    @if(!$hasTotp)
+        <img src="{{ $qrDataUri }}" alt="TOTP QR">
+        <div>
+            <p>{{ __('Secret') }}</p>
+            <strong>{{ $secret }}</strong>
+        </div>
+    @else
+        <p>{{ __('Enter your current TOTP code to continue.') }}</p>
+    @endif
+
+    <form method="POST" action="{{ route('totp.verify') }}">
+        @csrf
+        <x-form::input class="mb-3" type="text" name="code" id="code" label="{{ __('Authentication code') }}:" />
+        <div class="d-flex">
+            <x-form::button class="btn-primary" type="submit">{{ __('boilerplate::auth.login') }}</x-form::button>
+        </div>
+    </form>
+</div>
+</x-layout-auth>

--- a/prefabs/resources/views/auth/verify.blade copy.php
+++ b/prefabs/resources/views/auth/verify.blade copy.php
@@ -1,0 +1,50 @@
+<x-layout-auth>
+<div>
+    <h1>{{ __('auth.Verify') }}</h1>
+
+    {{ __('auth.checkEmail') }}
+    {{ __('auth.notReceiveEmail') }}
+
+    @if (session('resent'))
+        <div class="alert alert-success" role="alert">
+            {{ __('auth.sendEmail') }}
+        </div>
+    @endif
+
+    <form method="POST" action="{{ route('verification.resend') }}">
+        @csrf
+        <div class="d-flex">
+            <x-form::button class="btn-primary" type="submit">{{ __('resend') }}</x-form::button>
+        </div>
+    </form>
+</div>
+</x-layout-auth>
+
+
+
+<x-layout-auth>
+<div class="container-xl">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">{{ __('auth.Verify') }}</div>
+
+                <div class="card-body">
+                    @if (session('resent'))
+                        <div class="alert alert-success" role="alert">
+                            {{ __('auth.sendEmail') }}
+                        </div>
+                    @endif
+
+                    {{ __('auth.checkEmail') }}
+                    {{ __('auth.notReceiveEmail') }},
+                    <form class="d-inline" method="POST" action="{{ route('verification.resend') }}">
+                        @csrf
+                        <button type="submit" class="btn btn-link p-0 m-0 align-baseline">{{ __('auth.requestNew') }}</button>.
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</x-layout-auth>

--- a/src/Support/MenuItemLink.php
+++ b/src/Support/MenuItemLink.php
@@ -17,24 +17,76 @@ class MenuItemLink extends MenuItem
         }
     }
 
-    public function isUse(): bool
-    {
-        return Request::is(trim(route($this->route, $this->parameters, false), '/').'*');
-    }
+	public function debug(): void
+	{
+		$path = trim(request()->path(), '/');
+		$query = request()->getQueryString();
+		$fullUrl = $path . ($query ? '?' . $query : '');
 
-    public function isActive(): bool
-    {
-		$fullUrl = trim((request()->path() . '?'. request()->getQueryString()), '?');
-
-		if (preg_match('/livewire/', $fullUrl)) {
+		if (str_contains($fullUrl, 'livewire')) {
 			$fullUrl = request()->headers->get('referer');
 		}
 
-		if (empty($this->parameters) && request()->getQueryString() === null) {
-			$data = explode(".", $this->route);
-			return (preg_match("/{$data[0]}/", $fullUrl) && (empty($data[1]) || $data[1] == "index")) || trim($fullUrl) == trim(route($this->route, false), '/');
+		$routeParts = explode('.', $this->route);
+		$routeSegment = $routeParts[0];
+		$routeAction  = $routeParts[1] ?? 'index';
+		$routePath = trim(route($this->route, $this->parameters, false), '/');
+
+		dump([
+			'menu_route' => $this->route,
+			'route_segment' => $routeSegment,
+			'route_action' => $routeAction,
+			'current_path' => $path,
+			'query_string' => $query,
+			'full_url' => $fullUrl,
+			'route_path' => $routePath,
+		]);
+
+		$regex = '#/(?:[^/]+/)*' . preg_quote($routeSegment, '#') . '(?:/|$)#';
+
+		dump([
+			'segment_regex' => $regex,
+			'regex_match' => preg_match($regex, '/' . $path),
+			'is_index' => $routeAction === 'index',
+		]);
+	}
+
+	public function isUse(): bool
+	{
+		$current = Route::currentRouteName();
+
+		if (!$current) {
+			return false;
 		}
 
-		return (trim($fullUrl) == trim(route($this->route, $this->parameters, false), '/'));
-    }
+		return ($current === $this->route || str_starts_with($current, $this->route . '.'));
+	}
+
+  	 public function isActive(): bool
+	{
+		if (Route::currentRouteName() !== $this->route) {
+			return false;
+		}
+
+		foreach ($this->parameters as $key => $value) {
+			if ((string) request()->route($key) !== (string) $value) {
+				return false;
+			}
+		}
+
+		if ( empty($this->options['query']) && request()->query->count() > 0 ) {
+			return false;
+		}
+
+		// 4️⃣ pokud menu query má, musí sedět
+		if (!empty($this->options['query'])) {
+			foreach ($this->options['query'] as $key => $value) {
+				if ((string) request()->query($key) !== (string) $value) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
 }

--- a/src/Support/MenuItemLink.php
+++ b/src/Support/MenuItemLink.php
@@ -62,49 +62,53 @@ class MenuItemLink extends MenuItem
 
 	protected function resolveActiveRoute(): ?\Illuminate\Routing\Route
 	{
-		$current = Route::current();
+		return once(function () {
+			$current = Route::current();
 
-        if (! $current) {
-            return null;
-        }
+			if (! $current) {
+				return null;
+			}
 
-        if ($current->getName() !== 'livewire.message') {
-            return $current;
-        }
+			if ($current->getName() !== 'livewire.message') {
+				return $current;
+			}
 
-        $referer = request()->headers->get('referer');
+			$referer = request()->headers->get('referer');
 
-        if (! $referer) {
-            return $current;
-        }
+			if (! $referer) {
+				return $current;
+			}
 
-        try {
-            $matchRequest = HttpRequest::create($referer, 'GET');
+			try {
+				$matchRequest = HttpRequest::create($referer, 'GET');
 
-            return app('router')->getRoutes()->match($matchRequest);
-        } catch (\Throwable) {
-            return $current;
-        }
-    }
+				return app('router')->getRoutes()->match($matchRequest);
+			} catch (\Throwable) {
+				return $current;
+			}
+		});
+	}
 
     protected function resolveQueryParameters(): array
     {
-        if (Route::currentRouteName() === 'livewire.message') {
-            $referer = request()->headers->get('referer');
+        return once(function () {
+            if (Route::currentRouteName() === 'livewire.message') {
+                $referer = request()->headers->get('referer');
 
-            if ($referer) {
-                $queryString = parse_url($referer, PHP_URL_QUERY);
+                if ($referer) {
+                    $queryString = parse_url($referer, PHP_URL_QUERY);
 
-                if ($queryString) {
-                    parse_str($queryString, $query);
+                    if ($queryString) {
+                        parse_str($queryString, $query);
 
-                    return $query;
+                        return $query;
+                    }
+
+                    return [];
                 }
-
-                return [];
             }
-        }
 
-        return request()->query->all();
+            return request()->query->all();
+        });
     }
 }

--- a/src/Traits/Auditable.php
+++ b/src/Traits/Auditable.php
@@ -2,7 +2,7 @@
 
 namespace SteelAnts\LaravelBoilerplate\Traits;
 
-use App\Models\Activity;
+use SteelAnts\LaravelBoilerplate\Models\Activity;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 trait Auditable

--- a/src/Traits/CRUD.php
+++ b/src/Traits/CRUD.php
@@ -49,10 +49,10 @@ trait CRUD
             'static'             => true,
         ], $this->model_component ?? []);
 
-		//TODO: Fix if Better implementation is awailable is discoverable dont work if  extension of FormComponent is Extended form Component
-		if ((isset($this->model_component ) && $this->model_component != [])) {
-			unset($options['livewireComponents']);
-		}
+		//TODO: Fix if Better implementation is available is discoverable dont work if  extension of FormComponent is Extended form Component
+		// if ((isset($this->model_component ) && $this->model_component != [])) {
+		// 	unset($options['livewireComponents']);
+		// }
 
         return view(($this->views['index'] ?? 'boilerplate::crud'), [
 			'layout' 		 => $this->layout ?? config('boilerplate.layouts.default'),

--- a/tests/Unit/MenuItemLinkTest.php
+++ b/tests/Unit/MenuItemLinkTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace SteelAnts\LaravelBoilerplate\Tests\Unit;
+
+use Illuminate\Support\Facades\Route;
+use SteelAnts\LaravelBoilerplate\Support\MenuItemLink;
+use Tests\TestCase;
+
+class MenuItemLinkTest extends TestCase
+{
+    public function test_is_use_returns_true_for_current_route(): void
+    {
+        Route::middleware('web')->get('/dashboard', fn () => 'ok')->name('dashboard');
+        $this->refreshRouteLookups();
+
+        $item = new MenuItemLink('Dashboard', 'dashboard', 'dashboard');
+
+        $this->get('/dashboard');
+
+        $this->assertTrue($item->isUse());
+    }
+
+    public function test_is_use_returns_true_for_child_route(): void
+    {
+        Route::middleware('web')->get('/dashboard', fn () => 'ok')->name('dashboard');
+        Route::middleware('web')->get('/dashboard/settings', fn () => 'ok')->name('dashboard.settings');
+        $this->refreshRouteLookups();
+
+        $item = new MenuItemLink('Dashboard', 'dashboard', 'dashboard');
+
+        $this->get('/dashboard/settings');
+
+        $this->assertTrue($item->isUse());
+    }
+
+    public function test_is_active_requires_matching_route_parameters_and_query(): void
+    {
+        Route::middleware('web')->get('/users/{user}', fn ($user) => "User {$user}")->name('users.show');
+        $this->refreshRouteLookups();
+
+        $item = new MenuItemLink(
+            'User detail',
+            'user_show',
+            'users.show',
+            parameters: ['user' => 5],
+            options: ['query' => ['tab' => 'profile']]
+        );
+
+        $this->get('/users/5?tab=profile');
+
+        $this->assertTrue($item->isActive());
+    }
+
+    public function test_is_active_returns_false_when_route_parameter_differs(): void
+    {
+        Route::middleware('web')->get('/users/{user}', fn ($user) => "User {$user}")->name('users.show');
+        $this->refreshRouteLookups();
+
+        $item = new MenuItemLink(
+            'User detail',
+            'user_show',
+            'users.show',
+            parameters: ['user' => 5]
+        );
+
+        $this->get('/users/6');
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function test_is_active_returns_false_for_unexpected_query_parameters(): void
+    {
+        Route::middleware('web')->get('/users/{user}', fn ($user) => "User {$user}")->name('users.show');
+        $this->refreshRouteLookups();
+
+        $item = new MenuItemLink(
+            'User detail',
+            'user_show',
+            'users.show',
+            parameters: ['user' => 5]
+        );
+
+        $this->get('/users/5?extra=yes');
+
+        $this->assertFalse($item->isActive());
+    }
+
+    public function test_is_active_returns_false_when_expected_query_value_differs(): void
+    {
+        Route::middleware('web')->get('/users/{user}', fn ($user) => "User {$user}")->name('users.show');
+        $this->refreshRouteLookups();
+
+        $item = new MenuItemLink(
+            'User detail',
+            'user_show',
+            'users.show',
+            parameters: ['user' => 5],
+            options: ['query' => ['tab' => 'profile']]
+        );
+
+        $this->get('/users/5?tab=activity');
+
+        $this->assertFalse($item->isActive());
+    }
+
+    private function refreshRouteLookups(): void
+    {
+        Route::getRoutes()->refreshNameLookups();
+    }
+}


### PR DESCRIPTION
# MenuItemLink – Navigation Behavior Documentation

This document describes the **complete behavior matrix** for menu activation logic using the two methods:

- `isActive()` → determines **the currently active menu item**
- `isUse()` → determines **whether a menu section (parent) is in use / expanded**

The logic is **route-based**, not URL-based.

---

## `isActive()` – Active Menu Item

> Determines whether a **specific menu item** should be marked as active.

### Rules

- Compares **route names**
- Compares **route parameters**
- **Query parameters are evaluated only if explicitly defined**
- If the menu item **does not define query parameters** but the URL contains them → **inactive**

---

### `isActive()` – Behavior Matrix

| Current URL | Current Route Name | Menu Item Route | Route Params | Query Params (Menu) | Result | Reason |
|------------|--------------------|-----------------|--------------|---------------------|--------|--------|
| `/jammer-registration` | `jammer-registration.index` | `jammer-registration.index` | — | — | ✅ | Route matches, no query |
| `/jammer-registration?x=1` | `jammer-registration.index` | `jammer-registration.index` | — | — | ❌ | URL has query, menu does not |
| `/jammer-registration?x=1` | `jammer-registration.index` | `jammer-registration.index` | — | `['x' => 1]` | ✅ | Query matches |
| `/jammer-registration?x=2` | `jammer-registration.index` | `jammer-registration.index` | — | `['x' => 1]` | ❌ | Query mismatch |
| `/jammer/42` | `jammer.show` | `jammer.show` | `['id' => 42]` | — | ✅ | Route param matches |
| `/jammer/43` | `jammer.show` | `jammer.show` | `['id' => 42]` | — | ❌ | Route param mismatch |
| `/jammer/42?tab=edit` | `jammer.show` | `jammer.show` | `['id' => 42]` | — | ❌ | Unexpected query |
| `/jammer/42?tab=edit` | `jammer.show` | `jammer.show` | `['id' => 42]` | `['tab' => 'edit']` | ✅ | All conditions match |

---

## `isUse()` – Menu Section / Parent Item

> Determines whether a menu item should be considered **in use**,  
> typically used to **expand parent menu sections**.

### Rules

- Uses **route names only**
- Does **not** use URL paths or wildcards
- Performs **segment-safe prefix matching**
- Prevents false positives (e.g. `jammer` ≠ `jammer-registration`)

---

### `isUse()` – Behavior Matrix

| Current Route Name | Menu Item Route | Result | Reason |
|--------------------|-----------------|--------|--------|
| `jammer.index` | `jammer` | ✅ | Exact match |
| `jammer.edit` | `jammer` | ✅ | Prefix match (`jammer.`) |
| `jammer.show` | `jammer` | ✅ | Prefix match (`jammer.`) |
| `jammer-registration.index` | `jammer` | ❌ | Different namespace |
| `jammer-registration.edit` | `jammer` | ❌ | Different namespace |
| `jammer-registration.index` | `jammer-registration` | ✅ | Exact match |
| `jammer-registration.edit` | `jammer-registration` | ✅ | Prefix match (`jammer-registration.`) |
